### PR TITLE
*Some* support for Haskell

### DIFF
--- a/grader/compiler.py
+++ b/grader/compiler.py
@@ -15,6 +15,7 @@ class Compiler:
     COMPILE_LINE_CPP = "g++ -O2 -std=c++14 -w -s -static -o {path_executable} {path_source}"
     COMPILE_LINE_JAVA = "javac -nowarn -d {path_executable} {path_source}"
     COMPILE_LINE_PYTHON = "python3 -m pyflakes {path_source}"
+    COMPILE_LINE_HASKELL = "ghc -O2 -w -o {path_executable} {path_source}"
 
     @staticmethod
     def compile(language, path_source, path_executable):
@@ -27,6 +28,8 @@ class Compiler:
             return Compiler.compile_java(path_source, path_executable)
         elif language == "Python":
             return Compiler.compile_python(path_source, path_executable)
+        elif language == "Haskell":
+            return Compiler.compile_haskell(path_source, path_executable)
         else:
             raise ValueError("Unknown Language {}!".format(language))
 
@@ -155,3 +158,18 @@ class Compiler:
         copyfile(path_source, path_executable)
         return ""
 
+    @staticmethod
+    def compile_haskell(path_source, path_executable):
+        command = Compiler.COMPILE_LINE_HASKELL.format(path_executable=path_executable, path_source=path_source)
+        exit_code, stdout_output, stderr_output, compilation_time = Compiler.run_command(command)
+
+        if stderr_output != "":
+            return "Compilation error: " + stderr_output
+
+        if compilation_time > config.MAX_COMPILATION_TIME:
+            return "Compilation exceeded the time limit of {0:.2f} seconds.".format(config.MAX_COMPILATION_TIME)
+
+        if exit_code != 0:
+            return "Compilation exited with a non-zero exit code: {}".format(exit_code)
+
+        return ""

--- a/tests/language_detector/sources/hilbert.hs
+++ b/tests/language_detector/sources/hilbert.hs
@@ -1,0 +1,270 @@
+import Data.List
+
+type Name = String
+type Names = [Name]
+
+type Pred = String
+type Func = String
+type Const = String
+
+-- Figure out how I can create custom type out of an infinite generator for an example
+-- Also how to tie Language to Formula, since it's kinda weak now
+type Language = (Const, Pred, Func)
+data Term = Var Name
+          | C Const
+          | Fn Func Terms
+          deriving (Eq)
+
+instance Show Term where
+  show (Var x) = x
+  show (C const) = const
+  show (Fn f terms) = f ++ "(" ++ (foldr (++) "" (map (show) terms)) ++")"
+
+
+
+type Terms = [Term]
+
+data Formula = Termination
+             | Atom Pred Terms
+             | Not Formula
+             | Impl Formula Formula
+             | And Formula Formula
+             | Or Formula Formula
+             | Every Name Formula
+             | Exist Name Formula
+             | Substitution Formula Name Name
+             deriving (Eq)
+
+termVars :: Term -> Names
+termVars (Var x) = [x]
+termVars (C c) = []
+termVars (Fn f terms) = foldr (++) [] $ map (termVars) terms
+
+freeVars :: Formula -> Names
+freeVars Termination   = []
+freeVars (Atom _ pred)     = foldr (++) [] $ map (termVars) pred
+freeVars (Not fi)      = freeVars fi
+freeVars (Impl fi psi) = (freeVars fi) ++ (freeVars psi)
+freeVars (And fi psi) = (freeVars fi) ++ (freeVars psi)
+freeVars (Or fi psi) = (freeVars fi) ++ (freeVars psi)
+freeVars (Every x fi)  = (freeVars fi) \\ [x]
+freeVars (Exist x fi)  = (freeVars fi) \\ [x]
+freeVars fi@(Substitution _ _ _) = freeVars $ sub fi
+
+--
+boundVars :: Formula -> Names
+boundVars Termination   = []
+boundVars (Atom _ pred)       = []
+boundVars (Not fi)      = boundVars fi
+boundVars (Impl fi psi) = (boundVars fi) ++ (boundVars psi)
+boundVars (And fi psi) = (boundVars fi) ++ (boundVars psi)
+boundVars (Or fi psi) = (boundVars fi) ++ (boundVars psi)
+boundVars (Every x fi)  = (boundVars fi) ++ [x]
+boundVars (Exist x fi)  = (boundVars fi) ++ [x]
+boundVars fi@(Substitution _ _ _) = boundVars $ sub fi
+
+vars :: Formula -> Names
+vars fi = freeVars(fi) ++ boundVars(fi)
+
+sub :: Formula -> Formula
+sub (Substitution f x y) = f -- Placeholder
+
+--TODO: explicit Substitution
+
+instance Show Formula where
+  show (Termination)  = "⊥"
+  show (Atom p terms) = p ++ "(" ++ (foldr (++) "" (map (show) terms)) ++")"
+  show (Not fi) = "(" ++ "¬" ++ show fi ++ ")"
+  show (Impl fi psi) = "(" ++ show fi ++ "→" ++ show psi ++ ")"
+  show (And fi psi) = "(" ++ show fi ++ "∧" ++ show psi ++ ")"
+  show (Or fi psi) = "(" ++ show fi ++ "∨" ++ show psi ++ ")"
+  show (Exist var fi) = "(" ++ "∃" ++ var ++ show fi ++ ")"
+  show (Every var fi) = "(" ++ "∀" ++ var ++ show fi ++ ")"
+  show (Substitution fi x y) = show fi ++ "[" ++ x ++ "/" ++ y ++ "]"
+
+
+isAxiom :: Formula -> Bool
+isAxiom f = or (map ($ f) axioms)
+--
+axioms :: [Formula -> Bool]
+axioms = [ isImplAxiom1
+         , isImplAxiom2
+         , isAndAxiom1
+         , isAndAxiom2
+         , isOrAxiom1
+         , isOrAxiom2
+         , isEveryAxiom1
+         , isEveryAxiom2
+         , isExistAxiom1
+         , isExistAxiom2
+         , isDNAxiom
+         , isContradictionAxiom
+         ]
+
+-- Axioms for ->
+-- 1. (A → B → C) → (A → B) → A → C
+isImplAxiom1 :: Formula -> Bool
+isImplAxiom1 (Impl (Impl fi1 (Impl psi1 xi1)) (Impl (Impl fi2 psi2) (Impl fi3 xi2)))
+  = fi1 == fi2 && fi2 == fi3 && psi1 == psi2 && xi1 == xi2
+isImplAxiom1 _ = False
+
+-- 2. A → B → A
+isImplAxiom2 :: Formula -> Bool
+isImplAxiom2 (Impl fi (Impl psi xi)) = fi == xi
+isImplAxiom2 _ = False
+
+-- -- Axioms for && converted to -> and !
+-- -- 3 A ∧ B → A, A ∧ B → B
+isAndAxiom1 :: Formula -> Bool
+isAndAxiom1 (Impl (And fi psi) xi) = fi == xi || psi == xi
+isAndAxiom1 _ = False
+--
+-- -- 4 A → B → A ∧ B
+isAndAxiom2 :: Formula -> Bool
+isAndAxiom2 (Impl (Impl fi1 psi1) (And fi2 psi2)) = fi1 == fi2 && psi1 == psi2
+isAndAxiom2 _ = False
+
+-- --5 A → A ∨ B, B → A ∨ B
+isOrAxiom1 :: Formula -> Bool
+isOrAxiom1 (Impl fi (Or psi xi)) = fi == psi || fi == xi
+isOrAxiom1 _ = False
+--
+--6 ((A → C) → (B → C)) → ((A ∨ B) → C)
+isOrAxiom2 :: Formula -> Bool
+isOrAxiom2 (Impl (Impl (Impl a1 c1) (Impl b1 c2)) (Impl (Or a2 b2) c3)) = a1 == a2 && b1 == b2 && c1 == c2 && c2 == c3
+isOrAxiom2 _ = False
+
+-- -- 7 ∀xA → A[x 7→ t]
+isEveryAxiom1 :: Formula -> Bool
+isEveryAxiom1 (Impl (Every x fi) (Substitution psi y t)) = fi == psi && y == x
+isEveryAxiom1 _ = False
+
+-- 8 ∀x (B → A) → (B → ∀xA), ако x ∈/ FV(B)
+isEveryAxiom2 :: Formula -> Bool
+isEveryAxiom2 (Impl (Every x (Impl b1 a1)) (Impl b2 (Every y a2))) = x == y && b1 == b2 && a1 == a2 && (not $ elem x (freeVars b2))
+isEveryAxiom2 _ = False
+
+-- -- 9 A[x 7→ t] → ∃xA
+isExistAxiom1 :: Formula -> Bool
+isExistAxiom1 (Impl (Substitution fi x t) (Exist y psi)) = x == y && fi == psi
+isExistAxiom1 _ = False
+--
+-- -- 10 ∀x (A → B) → (∃xA → B), ако x ∈/ FV(B)
+isExistAxiom2 :: Formula -> Bool
+isExistAxiom2 (Impl (Every x (Impl a1 b1)) (Impl (Exist y a2) b2)) = x == y && a1 == a2 && b1 == b2 && (not $ elem x (vars b1))
+isExistAxiom2 _ = False
+--
+-- -- 11 double negation
+isDNAxiom :: Formula -> Bool
+isDNAxiom (Impl (Not (Not a)) b) = a == b
+isDNAxiom _ = False
+
+-- 12 every formula is true for a 
+isContradictionAxiom :: Formula -> Bool
+isContradictionAxiom (Impl Termination fi) = True
+isContradictionAxiom _ = False
+
+type Hypotheses = [Formula]
+
+isDeduction :: Hypotheses -> [Formula] -> Bool
+isDeduction hyp fs = isDeduction' hyp [] fs
+
+isTautology :: [Formula] -> Bool
+isTautology = isDeduction []
+
+isDeduction' :: Hypotheses -> [Formula] -> [Formula] -> Bool
+isDeduction' hyp proved [] = True
+isDeduction' hyp proved (f:fs)
+  | isAxiom f              = proveNext
+  | elem f hyp             = proveNext
+  | isModusPonens proved f = proveNext
+  | isGen     hyp proved f = proveNext
+  | otherwise              = False
+  where proveNext = isDeduction' hyp (f : proved) fs
+
+-- Wrong because f doesn't bind to f in comprehension, it's a different f
+-- isModusPonens proved f = or [ elem x proved | (Impl x f) <- proved ]
+
+isModusPonens :: [Formula] -> Formula -> Bool
+isModusPonens proved f = any (\ (Impl x _) -> elem x proved) impls
+  where impls = [impl | impl@(Impl _ fi) <- proved,
+                        fi == f]
+
+isGen :: Hypotheses -> [Formula] -> Formula -> Bool
+isGen gama proved (Every x fi) = fi `elem` proved && (not $ elem x fvGama)
+  where
+    fvGama = foldr (++) [] $ map freeVars gama
+isGen _ _ _ = False
+
+tau :: Term
+tau = Var "x"
+
+x = Atom "p" [tau]
+y = Atom ""
+target = Impl x x
+
+proof = [
+  (Impl x (Impl target x)),
+  (Impl (Impl x (Impl target x)) (Impl (Impl x target) (Impl x x))),
+  (Impl (Impl x target) (Impl x x)),
+  (Impl x (Impl x x)),
+  target
+  ]
+
+-- A && B |- B && A
+
+a = Atom "A" [tau]
+b = Atom "B" [tau]
+
+hyp1 = [
+         (And b a)
+       ]
+
+test1 = (Impl (Impl a b) a)
+proof1 = [ (And b a)
+         , (Impl (And b a) a)
+         , a -- MP
+         , (Impl a (Impl a b)) -- axiom
+         , (Impl a b) -- MP
+         , (Impl (Impl a b) (And a b))
+         , (And a b)
+         ]
+
+
+wrong1 = [ (And b a)
+         , (Impl (And b a) a)
+         , a -- MP
+         , (Impl (Impl a b) a) -- axiom
+         , (Impl a b) -- MP
+         , (Impl (Impl a b) (And a b))
+         , (And a b)
+         ]
+
+-- TODO:
+--
+tau1 :: Term
+tau1 = Var "y"
+
+px = Atom "p" [tau]
+py = Atom "p" [tau1]
+
+-- goal: (Every y py)
+hyp2 = [
+        (Every "x" px)
+       ]
+proof2 =  [ (Every "x" px)
+          , (Impl (Every "x" px) (Substitution px "x" "y"))
+          , (Substitution px "x" "y")
+          , (Every "y" (Substitution px "x" "y"))
+          ]
+
+-- goal: (Not a)
+--
+hyp3 = [
+          (Not (Not (Not a)))
+       ]
+
+proof3 = [ (Not (Not (Not a)))
+         , (Impl (Not (Not (Not a))) (Not a))
+         , (Not a)
+         ]

--- a/tests/language_detector/sources/io.hs
+++ b/tests/language_detector/sources/io.hs
@@ -1,0 +1,17 @@
+(<>) :: Int -> Int -> Bool
+(<>) = (/=)
+
+ioMax :: Int -> Int -> IO (Maybe Int)
+ioMax x y
+    |x < y = return (Just y)
+    |x == y = do
+                return Nothing
+                return Nothing
+    |otherwise = return (Just x)
+
+
+main = do
+    a <- getLine
+    b <- getLine
+    max <- ioMax (read a :: Int) (read b :: Int)
+    putStrLn (show max)

--- a/tests/language_detector/test.html
+++ b/tests/language_detector/test.html
@@ -1,12 +1,18 @@
 <html>
     <script type="text/javascript" src="../../web/scripts/language_detector.js"></script>
+
     <script>readFile("./sources/EllysBounceGame.java", "Java");</script>
     <script>readFile("./sources/EllysXors.java", "Java");</script>
+
     <script>readFile("./sources/IncludeWithSpace.cpp", "C++");</script>
     <script>readFile("./sources/problem08.cpp", "C++");</script>
     <script>readFile("./sources/problem09.cpp", "C++");</script>
     <script>readFile("./sources/TrySail.cpp", "C++");</script>
+
     <script>readFile("./sources/problem55.py", "Python");</script>
     <script>readFile("./sources/problem56.py", "Python");</script>
     <script>readFile("./sources/problem57.py", "Python");</script>
+
+    <script>readFile("./sources/io.hs", "Haskell");</script>
+    <script>readFile("./sources/hilbert.hs", "Haskell");</script>
 </html>

--- a/web/scripts/language_detector.js
+++ b/web/scripts/language_detector.js
@@ -274,10 +274,12 @@ function detectLanguage(code) {
     var keywordsHaskell = ["type", "newtype", "data", "forall", "infixl", "infixr", "infix", "let", "where", "module",
                            "=>", "<-", "deriving", "instance"];
 
-    var scores = [0, 0, 0];
+    var scores = [0, 0, 0, 0];
 
     var codeWithoutCStyleComments = removeCStyleComments(removeSpaces(code), "\\\\", "\\*", "*\\");
     var codeWithoutPyStyleComments = removePyStyleComments(code);
+    var codeWithoutHaskellComments = removeCStyleComments(code, "--", "{-", "-}");
+
 
     keywordsCpp.forEach(function(item) {
         scoreByKeyword(codeWithoutCStyleComments, scores, 0, keywordType.STRONG, item);
@@ -300,19 +302,26 @@ function detectLanguage(code) {
         scoreByKeyword(codeWithoutPyStyleComments, scores, 2, keywordType.WEAK, item);
     });
 
+    keywordsHaskell.forEach(function(item) {
+        scoreByKeyword(codeWithoutHaskellComments, scores, 3, keywordType.STRONG, item);
+    });
+
     var cppScore    = scores[0];
     var javaScore   = scores[1];
     var pythonScore = scores[2];
+    var haskellScore = scores[3];
 
     cppScore    /= codeWithoutCStyleComments.length;  // cpp score
     javaScore   /= codeWithoutCStyleComments.length;  // java score
     pythonScore /= codeWithoutPyStyleComments.length; // python score
+    haskellScore /= codeWithoutHaskellComments.length; // haskell score
 
     /*
     console.log("C++ score: " + cppScore)
     console.log("Java score: " + javaScore)
     console.log("Python score: " + pythonScore)
     */
+    scores.sort((lhs, rhs) => (lhs - rhs));
 
-    return (javaScore < cppScore) ? ((pythonScore < cppScore) ? "C++" : "Python") : ((javaScore < pythonScore) ? "Python" : "Java");
+    return scores[0];
 }

--- a/web/scripts/language_detector.js
+++ b/web/scripts/language_detector.js
@@ -271,6 +271,9 @@ function detectLanguage(code) {
 
     var keywordsPythonAndJava = ["import"];
 
+    var keywordsHaskell = ["type", "newtype", "data", "forall", "infixl", "infixr", "infix", "let", "where", "module",
+                           "=>", "<-", "deriving", "instance"];
+
     var scores = [0, 0, 0];
 
     var codeWithoutCStyleComments = removeCStyleComments(removeSpaces(code), "\\\\", "\\*", "*\\");

--- a/web/scripts/language_detector.js
+++ b/web/scripts/language_detector.js
@@ -132,7 +132,6 @@ function removeCStyleComments(code, singleLineStart, multiLineStart, multiLineEn
         }
     }
 
-    code = removeSpaces(code);
 
     return code;
 }
@@ -274,7 +273,7 @@ function detectLanguage(code) {
 
     var scores = [0, 0, 0];
 
-    var codeWithoutCStyleComments = removeCStyleComments(code);
+    var codeWithoutCStyleComments = removeCStyleComments(removeSpaces(code), "\\\\", "\\*", "*\\");
     var codeWithoutPyStyleComments = removePyStyleComments(code);
 
     keywordsCpp.forEach(function(item) {

--- a/web/scripts/language_detector.js
+++ b/web/scripts/language_detector.js
@@ -306,22 +306,25 @@ function detectLanguage(code) {
         scoreByKeyword(codeWithoutHaskellComments, scores, 3, keywordType.STRONG, item);
     });
 
-    var cppScore    = scores[0];
-    var javaScore   = scores[1];
-    var pythonScore = scores[2];
-    var haskellScore = scores[3];
+    var cppScore    = [scores[0], "C++"];
+    var javaScore    = [scores[1], "Java"];
+    var pythonScore    = [scores[2], "Python"];
+    var cppScore    = [scores[3], "Haskell"];
 
-    cppScore    /= codeWithoutCStyleComments.length;  // cpp score
-    javaScore   /= codeWithoutCStyleComments.length;  // java score
-    pythonScore /= codeWithoutPyStyleComments.length; // python score
-    haskellScore /= codeWithoutHaskellComments.length; // haskell score
 
-    /*
-    console.log("C++ score: " + cppScore)
-    console.log("Java score: " + javaScore)
-    console.log("Python score: " + pythonScore)
-    */
-    scores.sort((lhs, rhs) => (lhs - rhs));
+    cppScore[0]    /= codeWithoutCStyleComments.length;  // cpp score
+    javaScore[0]   /= codeWithoutCStyleComments.length;  // java score
+    pythonScore[0] /= codeWithoutPyStyleComments.length; // python score
+    haskellScore[0] /= codeWithoutHaskellComments.length; // haskell score
 
-    return scores[0];
+    var associatedScores = [cppScore, javaScore, pythonScore, haskellScore];
+
+    console.log("C++ score: " + cppScore[0])
+    console.log("Java score: " + javaScore[0])
+    console.log("Python score: " + pythonScore[0])
+    console.log("Haskell score: " + haskellScore[0])
+
+    scores.sort((lhs, rhs) => (lhs[0] - rhs[0]));
+
+    return scores[3][1];
 }

--- a/web/scripts/language_detector.js
+++ b/web/scripts/language_detector.js
@@ -32,8 +32,9 @@ function removeSpaces(code) {
      return code;
 }
 
-/* Removes C style comments and strings from code */
-function removeCStyleComments(code) {
+/* Removes C style comments and strings from code 
+ * with generic two character comments being possible*/
+function removeCStyleComments(code, singleLineStart, multiLineStart, multiLineEnd) {
     var states = {
         DEFAULT    : 0, // default state
         STRING     : 1, // string state
@@ -44,8 +45,8 @@ function removeCStyleComments(code) {
     var curState       = states.DEFAULT;
     var curIndex       = 0;
     var startString    = 0; // start index of a string
-    var startMLComment = 0; // start index of a multiline comment
     var startSLComment = 0; // start index of a single line comment
+    var startMLComment = 0; // start index of a multiline comment
 
    while (curIndex < code.length) {
         switch (code[curIndex]) {
@@ -76,20 +77,26 @@ function removeCStyleComments(code) {
                     } else ++curIndex;
                 } else ++curIndex;
                 break;
-            case '/':
+            case singleLineStart[0]:
                 if ((curIndex + 1) < code.length && curState == states.DEFAULT) {
-                    if (code[curIndex + 1] == '/') {
+                    if (code[curIndex + 1] == singleLineStart[1]) {
                         startSLComment = curIndex;
                         curState = states.SL_COMMENT;
-                    } else if (code[curIndex + 1] == '*') {
+                    }
+                }
+                ++curIndex;
+                break;
+            case multiLineStart[0]:
+                if ((curIndex + 1) < code.length && curState == states.DEFAULT) {
+                    if (code[curIndex + 1] == multiLineStart[1]) {
                         startMLComment = curIndex;
                         curState = states.ML_COMMENT;
                     }
                 }
                 ++curIndex;
                 break;
-           case '*':
-                if ((curIndex + 1) < code.length && code[curIndex + 1] == '/' && curState == states.ML_COMMENT) {
+           case multiLineEnd[0]:
+                if ((curIndex + 1) < code.length && code[curIndex + 1] == multiLineEnd[1] && curState == states.ML_COMMENT) {
                     // remove multi line comment
                     code = code.substring(0, startMLComment) + (((curIndex + 2) < code.length) ? code.substring(curIndex + 2) : '');
                     curIndex = startMLComment;
@@ -124,6 +131,7 @@ function removeCStyleComments(code) {
                 break;
         }
     }
+
     code = removeSpaces(code);
 
     return code;


### PR DESCRIPTION
Adding some boilerplate for Haskell (compiler.py) which was untested as it is "isomorphic" to the cpp version.
Also adding *some* support for the language detector - 
1) Generalising the "remove c-style comments function" by allowing you to pass what two symbols indicate a single-line comment and what two symbols start and end a multi-line comment.
2) Adding Haskell keywords (need more probably, considering adding " -> ", but it's obviously shared)
3) Rewriting a bit of the detectLanguage function to use an associated list instead of manually *InsertionSort*-ing the numbers.

This however went untested due to my general lack of experience (literally none) with JS and inability to actually run the test ._. (the tests are added though)
Happily taking recommendations on making this work/making this better